### PR TITLE
feat: optimistron api change

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,12 @@ This runs on every reducer call, gated by referential equality (`===`) to skip w
 
 ### TransitionState\<T\>
 
-Wraps your state `T` with a `transitions` list and a namespace key. Both internal fields are **non-enumerable** — your state spreads cleanly and serializers ignore them.
+Wraps your state `T` with a `transitions` list. The `transitions` field is **non-enumerable** — your state spreads cleanly and serializers ignore it.
 
 ```typescript
 type TransitionState<T> = {
     state: T;
     transitions: StagedAction[]; // non-enumerable
-    [REDUCER_KEY]: string; // non-enumerable
 };
 ```
 
@@ -210,7 +209,7 @@ Each returns `{ stage, amend, commit, fail, stash, match }` — action creators 
 ```typescript
 import { optimistron, indexedStateFactory } from '@lostsolution/optimistron';
 
-const todos = optimistron(
+const { reducer: todos, selectOptimistic } = optimistron(
     'todos', // namespace
     initialState, // initial state
     indexedStateFactory<Todo>({ itemIdKey: 'id', compare, eq }), // state handler
@@ -224,7 +223,7 @@ const todos = optimistron(
 );
 ```
 
-The reducer receives a **bound state handler** — not the raw state. This ensures all mutations go through the handler's CRUD operations, keeping them granular and mergeable.
+`optimistron()` returns `{ reducer, selectOptimistic }`. The reducer receives a **bound state handler** — not the raw state. The `selectOptimistic` is scoped to this reducer instance — no global state.
 
 ### 3. Dispatch transitions
 
@@ -247,7 +246,8 @@ try {
 
 ```typescript
 import { createSelector } from '@reduxjs/toolkit';
-import { selectOptimistic, selectIsOptimistic, selectIsFailed, selectIsConflicting } from '@lostsolution/optimistron';
+import { selectIsOptimistic, selectIsFailed, selectIsConflicting } from '@lostsolution/optimistron';
+import { selectOptimistic } from './reducer'; // returned from optimistron()
 
 // Derive the optimistic view — transitions replayed on committed state
 const selectTodos = createSelector(
@@ -267,4 +267,4 @@ const selectTodoStatus = (id: string) =>
     );
 ```
 
-`selectOptimistic` replays transitions on every call — wrap with `createSelector` for memoization.
+`selectOptimistic` replays transitions on every call — wrap with `createSelector` for memoization. It is returned from `optimistron()`, not a standalone import.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,1 @@
 export const META_KEY = '__OPTIMISTRON_META__' as const;
-export const REDUCER_KEY = '__OPTIMISTRON_REF_ID__' as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ export {
     selectIsConflicting,
     selectIsFailed,
     selectIsOptimistic,
-    selectOptimistic,
 } from './selectors';
 export { indexedStateFactory, type IndexedState } from './state/indexed';
 export { DedupeMode, Operation, OptimisticMergeResult, isTransition } from './transitions';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 /** Development-only warning logger. Calls are eliminated
  * by bundlers when `process.env.NODE_ENV === 'production'` */
-export const warn = (...args: any[]) => {
+export const warn = (...args: unknown[]) => {
     if (process.env.NODE_ENV !== 'production') console.warn(...args);
 };

--- a/src/optimistron.ts
+++ b/src/optimistron.ts
@@ -1,7 +1,8 @@
 import type { Action, Reducer } from 'redux';
 
 import { warn } from './logger';
-import { ReducerMap, bindReducer, type HandlerReducer } from './reducer';
+import { bindReducer, type BoundReducer, type HandlerReducer } from './reducer';
+import { createSelectOptimistic } from './selectors';
 import type { StateHandler, TransitionState } from './state';
 import { bindStateFactory, buildTransitionState, transitionStateFactory } from './state';
 import {
@@ -12,29 +13,39 @@ import {
     processTransition,
     sanitizeTransitions,
     toCommit,
+    type StagedAction,
 } from './transitions';
 
-export const optimistron = <S, C extends any[], U extends any[], D extends any[]>(
+/** Applies a staged transition as a commit via the bound reducer.
+ * Returns undefined if no matching staged action exists. */
+const commitTransition = <S>(
+    boundReducer: BoundReducer<S>,
+    transitionState: TransitionState<S>,
+    transitions: StagedAction[],
+    id: string,
+): S | undefined => {
+    const staged = transitions.find((entry) => id === getTransitionID(entry));
+    if (!staged) return undefined;
+    return boundReducer(transitionState, toCommit(staged));
+};
+
+export const optimistron = <S, C extends unknown[], U extends unknown[], D extends unknown[]>(
     namespace: string,
     initialState: S,
     handler: StateHandler<S, C, U, D>,
     reducer: HandlerReducer<S, C, U, D>,
     options?: { sanitizeAction: <T extends Action>(action: T) => T },
-): Reducer<TransitionState<S>> => {
+): { reducer: Reducer<TransitionState<S>>; selectOptimistic: ReturnType<typeof createSelectOptimistic<S>> } => {
     if (!namespace) throw new Error('optimistron: namespace cannot be empty');
 
     const bindState = bindStateFactory<S, C, U, D>(handler);
     const boundReducer = bindReducer(reducer, bindState);
 
-    /* keep a reference to the underlying reducer in order for optimistic
-     * selectors to apply the optimistic transitions when executed */
-    if (ReducerMap.has(namespace)) throw new Error(`An optimistic reducer for [${namespace}] is already registered`);
-    ReducerMap.set(namespace, boundReducer);
-
     const sanitizer = sanitizeTransitions(boundReducer, bindState);
-    const initial = buildTransitionState(initialState, [], namespace);
+    const initial = buildTransitionState(initialState, []);
+    const selectOptimistic = createSelectOptimistic<S>(boundReducer, namespace);
 
-    return (transitionState = initial, action) => {
+    const optimisticReducer: Reducer<TransitionState<S>> = (transitionState = initial, action) => {
         const nextTransitionState: TransitionState<S> = (() => {
             const { state, transitions } = transitionState;
             const next = transitionStateFactory(transitionState);
@@ -48,13 +59,8 @@ export const optimistron = <S, C extends any[], U extends any[], D extends any[]
                     const { operation, id } = getTransitionMeta(action);
 
                     if (operation === Operation.COMMIT) {
-                        /* Find the matching staged action in the transition list.
-                         * Treat it as a commit if it exists - noop otherwise */
-                        const staged = transitions.find((entry) => id === getTransitionID(entry));
-                        if (!staged) return next(state, nextTransitions);
-
-                        /* Committing will apply the action to the reducer */
-                        return next(boundReducer(transitionState, toCommit(staged)), nextTransitions);
+                        const committed = commitTransition(boundReducer, transitionState, transitions, id);
+                        return next(committed ?? state, nextTransitions);
                     }
 
                     /* Every other transition actions will not be applied.
@@ -79,4 +85,6 @@ export const optimistron = <S, C extends any[], U extends any[], D extends any[]
 
         return nextTransitionState;
     };
+
+    return { reducer: optimisticReducer, selectOptimistic };
 };

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -5,15 +5,13 @@ export type BoundReducer<State = any> = (state: TransitionState<State>, action: 
 
 export type HandlerReducer<
     State,
-    CreateParams extends any[],
-    UpdateParams extends any[],
-    DeleteParams extends any[],
+    CreateParams extends unknown[],
+    UpdateParams extends unknown[],
+    DeleteParams extends unknown[],
 > = (boundStateHandler: BoundStateHandler<State, CreateParams, UpdateParams, DeleteParams>, action: Action) => State;
 
-export const ReducerMap = new Map<string, BoundReducer>();
-
 export const bindReducer =
-    <S, C extends any[], U extends any[], D extends any[]>(
+    <S, C extends unknown[], U extends unknown[], D extends unknown[]>(
         reducer: HandlerReducer<S, C, U, D>,
         bindState: (state: S) => BoundStateHandler<S, C, U, D>,
     ): BoundReducer<S> =>

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,15 +1,14 @@
-import { REDUCER_KEY } from './constants';
 import { warn } from './logger';
-import { ReducerMap } from './reducer';
+import type { BoundReducer } from './reducer';
 import { type TransitionState } from './state';
 import { getTransitionMeta, toCommit } from './transitions';
 
-export const selectOptimistic =
-    <State, Slice>(selector: (state: TransitionState<State>) => Slice) =>
+/** Creates a `selectOptimistic` selector closed over the bound reducer.
+ * Used internally by `optimistron()` — not part of the public API. */
+export const createSelectOptimistic =
+    <State>(boundReducer: BoundReducer<State>, namespace: string) =>
+    <Slice>(selector: (state: TransitionState<State>) => Slice) =>
     (state: TransitionState<State>): Slice => {
-        const boundReducer = ReducerMap.get(state[REDUCER_KEY]);
-        if (!boundReducer) return selector(state);
-
         /** Fast-path: no transitions to replay */
         if (!state.transitions.length) return selector(state);
 
@@ -24,7 +23,7 @@ export const selectOptimistic =
 
             return selector(optimisticState);
         } catch (error) {
-            warn(`selectOptimistic: error replaying transitions for "${state[REDUCER_KEY]}"`, error);
+            warn(`selectOptimistic: error replaying transitions for "${namespace}"`, error);
             return selector(state);
         }
     };

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,10 +1,8 @@
-import { REDUCER_KEY } from './constants';
 import type { StagedAction, TransitionAction } from './transitions';
 
 export type TransitionState<T> = {
     state: T;
     transitions: StagedAction[];
-    [REDUCER_KEY]: string;
 };
 
 type ItemIdKeys<T> = {
@@ -26,9 +24,9 @@ export type StateHandlerOptions<T> = {
 
 export interface StateHandler<
     State,
-    CreateParams extends any[],
-    UpdateParams extends any[],
-    DeleteParams extends any[],
+    CreateParams extends unknown[],
+    UpdateParams extends unknown[],
+    DeleteParams extends unknown[],
 > {
     create: (state: State, ...args: CreateParams) => State;
     update: (state: State, ...args: UpdateParams) => State;
@@ -38,9 +36,9 @@ export interface StateHandler<
 
 export interface BoundStateHandler<
     State,
-    CreateParams extends any[],
-    UpdateParams extends any[],
-    DeleteParams extends any[],
+    CreateParams extends unknown[],
+    UpdateParams extends unknown[],
+    DeleteParams extends unknown[],
 > {
     create: (...args: CreateParams) => State;
     update: (...args: UpdateParams) => State;
@@ -50,7 +48,7 @@ export interface BoundStateHandler<
 }
 
 export const bindStateFactory =
-    <State, CreateParams extends any[], UpdateParams extends any[], DeleteParams extends any[]>(
+    <State, CreateParams extends unknown[], UpdateParams extends unknown[], DeleteParams extends unknown[]>(
         handler: StateHandler<State, CreateParams, UpdateParams, DeleteParams>,
     ) =>
     (state: State): BoundStateHandler<State, CreateParams, UpdateParams, DeleteParams> => ({
@@ -61,28 +59,21 @@ export const bindStateFactory =
         getState: () => state,
     });
 
-export const isTransitionState = <State>(state: any): state is TransitionState<State> => REDUCER_KEY in state;
+export const buildTransitionState = <State>(state: State, transitions: TransitionAction[]): TransitionState<State> => {
+    const transitionState = { state } as TransitionState<State>;
 
-type UnwrapTransitionState<T> = T extends TransitionState<any> ? T : TransitionState<T>;
-
-export const buildTransitionState = <State>(state: State, transitions: TransitionAction[], namespace: string) => {
-    const transitionState = isTransitionState<State>(state)
-        ? Object.assign({}, state)
-        : { state, transitions, [REDUCER_KEY]: namespace };
-
-    /* make internal properties non-enumerable to avoid consumers
+    /* make transitions non-enumerable to avoid consumers
      * from unintentionally accessing them when iterating */
     Object.defineProperties(transitionState, {
-        transitions: { value: transitions, enumerable: false },
-        [REDUCER_KEY]: { value: namespace, enumerable: false },
+        transitions: { value: transitions, enumerable: false, writable: true },
     });
 
-    return transitionState as UnwrapTransitionState<State>;
+    return transitionState;
 };
 
 export const transitionStateFactory =
     <State>(prev: TransitionState<State>) =>
     (state: State, transitions: TransitionAction[]): TransitionState<State> => {
         if (state === prev.state && transitions === prev.transitions) return prev;
-        return buildTransitionState(state, transitions, prev[REDUCER_KEY]);
+        return buildTransitionState(state, transitions);
     };

--- a/src/transitions.ts
+++ b/src/transitions.ts
@@ -155,7 +155,7 @@ export const processTransition = (transition: TransitionAction, transitions: Sta
  * and performing a sanity 'merge' check on each iteration. This process helps cleanse the transitions
  * list by eliminating no-op actions and identifying potential conflicts. */
 export const sanitizeTransitions =
-    <State, CreateParams extends any[], UpdateParams extends any[], DeleteParams extends any[]>(
+    <State, CreateParams extends unknown[], UpdateParams extends unknown[], DeleteParams extends unknown[]>(
         boundReducer: BoundReducer<State>,
         bindState: ReturnType<typeof bindStateFactory<State, CreateParams, UpdateParams, DeleteParams>>,
     ) =>

--- a/test/integration/indexed.spec.ts
+++ b/test/integration/indexed.spec.ts
@@ -1,17 +1,14 @@
 import { afterAll, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import { optimistron } from '~optimistron';
-import { ReducerMap } from '~reducer';
-import { selectIsConflicting, selectIsFailed, selectIsOptimistic, selectOptimistic } from '~selectors';
+import { selectIsConflicting, selectIsFailed, selectIsOptimistic } from '~selectors';
 import { buildTransitionState } from '~state';
 import type { TestIndexedState } from '~test/utils';
 import { create, createItem, edit, indexedState, reducer, remove, selectState, sync, throwAction } from '~test/utils';
 import { toStaged, updateTransition } from '~transitions';
 
 describe('optimistron', () => {
-    afterAll(() => ReducerMap.clear());
-
-    const optimisticReducer = optimistron('test', {}, indexedState, reducer);
+    const { reducer: optimisticReducer, selectOptimistic } = optimistron('test', {}, indexedState, reducer);
 
     describe('IndexedState', () => {
         describe('create', () => {
@@ -26,7 +23,7 @@ describe('optimistron', () => {
             const commit = create.commit(item.id);
             const conflict = create.stage(item.id, conflictItem);
 
-            const initial = buildTransitionState(<TestIndexedState>{}, [], 'test');
+            const initial = buildTransitionState(<TestIndexedState>{}, []);
             const state = optimisticReducer(initial, stage);
 
             describe('stage', () => {
@@ -145,7 +142,7 @@ describe('optimistron', () => {
 
     test('should warn and return unchanged state on reducer error', () => {
         const warn = spyOn(console, 'warn').mockImplementation(mock());
-        const initial = buildTransitionState(<TestIndexedState>{}, [], 'test');
+        const initial = buildTransitionState(<TestIndexedState>{}, []);
         const state = optimisticReducer(initial, throwAction);
 
         expect(state.state).toStrictEqual(initial.state);
@@ -163,7 +160,7 @@ describe('optimistron', () => {
         const stash = remove.stash(item.id);
         const commit = remove.commit(item.id);
 
-        const initial = buildTransitionState(<TestIndexedState>{ [item.id]: item }, [], 'test');
+        const initial = buildTransitionState(<TestIndexedState>{ [item.id]: item }, []);
         const state = optimisticReducer(initial, stage);
 
         describe('stage', () => {
@@ -236,7 +233,7 @@ describe('optimistron', () => {
         const commit = edit.commit(updatedItem.id);
         const conflict = edit.stage(updatedItem.id, conflictItem);
 
-        const initial = buildTransitionState(<TestIndexedState>{ [item.id]: item }, [], 'test');
+        const initial = buildTransitionState(<TestIndexedState>{ [item.id]: item }, []);
         const state = optimisticReducer(initial, stage);
 
         describe('stage', () => {

--- a/test/unit/optimistron.spec.ts
+++ b/test/unit/optimistron.spec.ts
@@ -1,28 +1,25 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 
 import { optimistron } from '~optimistron';
-import { ReducerMap } from '~reducer';
 import { create, createItem, indexedState, reducer } from '~test/utils';
 import { toCommit } from '~transitions';
 
 describe('optimistron', () => {
-    afterEach(() => ReducerMap.clear());
-
     const item = createItem();
 
-    test('should register reducer on `ReducerMap`', () => {
-        optimistron('test', {}, indexedState, reducer);
-        expect(ReducerMap.get('test')).toBeDefined();
+    test('should return reducer and selectOptimistic', () => {
+        const result = optimistron('test', {}, indexedState, reducer);
+        expect(result.reducer).toBeFunction();
+        expect(result.selectOptimistic).toBeFunction();
     });
 
-    test('should throw if re-registering same action namespace', () => {
-        optimistron('test', {}, indexedState, reducer);
-        expect(() => optimistron('test', {}, indexedState, reducer)).toThrow();
+    test('should throw if namespace is empty', () => {
+        expect(() => optimistron('', {}, indexedState, reducer)).toThrow();
     });
 
     test('should support action sanitization', () => {
         const sanitizeAction = mock((action) => action);
-        const optimisticReducer = optimistron('test', {}, indexedState, reducer, { sanitizeAction });
+        const { reducer: optimisticReducer } = optimistron('test', {}, indexedState, reducer, { sanitizeAction });
         const initial = optimisticReducer(undefined, { type: 'init' });
         const stage = create.stage(item.id, item);
 
@@ -31,7 +28,7 @@ describe('optimistron', () => {
     });
 
     test('should handle non-transition actions', () => {
-        const optimisticReducer = optimistron('test', {}, indexedState, reducer);
+        const { reducer: optimisticReducer } = optimistron('test', {}, indexedState, reducer);
         const initial = optimisticReducer(undefined, { type: 'init' });
         const nextState = optimisticReducer(initial, { type: 'any-action' });
 
@@ -40,7 +37,7 @@ describe('optimistron', () => {
     });
 
     test('committing a non-staged action should noop', () => {
-        const optimisticReducer = optimistron('test', {}, indexedState, reducer);
+        const { reducer: optimisticReducer } = optimistron('test', {}, indexedState, reducer);
         const initial = optimisticReducer(undefined, { type: 'init' });
         const commit = create.commit(item.id);
         const nextState = optimisticReducer(initial, commit);
@@ -51,7 +48,7 @@ describe('optimistron', () => {
 
     test('committing should resolve staged transition and apply as if committed', () => {
         const testReducerSpy = mock(reducer);
-        const optimisticReducer = optimistron('test', {}, indexedState, testReducerSpy);
+        const { reducer: optimisticReducer } = optimistron('test', {}, indexedState, testReducerSpy);
         const initial = optimisticReducer(undefined, { type: 'init' });
         const staged = create.stage(item.id, item);
         const commit = create.commit(item.id);

--- a/test/unit/reducer.spec.ts
+++ b/test/unit/reducer.spec.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
-import { REDUCER_KEY } from '~constants';
 import { bindReducer } from '~reducer';
 import type { TransitionState } from '~state';
 import { bindStateFactory } from '~state';
@@ -17,7 +16,6 @@ describe('bindReducer', () => {
     const transitionState: TransitionState<TestIndexedState> = {
         transitions: [],
         state: { [item.id]: item },
-        [REDUCER_KEY]: 'test-reducer',
     };
 
     beforeEach(() => innerReducer.mockClear());

--- a/test/unit/selectors.spec.ts
+++ b/test/unit/selectors.spec.ts
@@ -1,7 +1,5 @@
-import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
-import { REDUCER_KEY } from '~constants';
+import { afterAll, describe, expect, mock, spyOn, test } from 'bun:test';
 import { optimistron } from '~optimistron';
-import { ReducerMap } from '~reducer';
 import {
     selectConflictingTransition,
     selectFailedTransition,
@@ -9,15 +7,11 @@ import {
     selectIsConflicting,
     selectIsFailed,
     selectIsOptimistic,
-    selectOptimistic,
 } from '~selectors';
-import { create, createIndexedState, createItem, indexedState, reducer, selectState, throwAction } from '~test/utils';
+import { create, createIndexedState, createItem, indexedState, reducer, selectState } from '~test/utils';
 import { updateTransition } from '~transitions';
 
 describe('selectors', () => {
-    beforeEach(() => optimistron('test', {}, indexedState, reducer));
-    afterEach(() => ReducerMap.clear());
-
     const item = createItem();
     const stage = create.stage(item.id, item);
 
@@ -26,22 +20,20 @@ describe('selectors', () => {
         const warn = spyOn(console, 'warn').mockImplementation(mock());
         afterAll(() => warn.mockRestore());
 
-        test('should apply default selector if no registered reducer', () => {
-            expect(
-                selectOptimistic(() => 1337)({
-                    transitions: [],
-                    [REDUCER_KEY]: 'unknown',
-                    state: 42,
-                }),
-            ).toEqual(1337);
+        test('should fast-path when no transitions', () => {
+            const { selectOptimistic } = optimistron('test', {}, indexedState, reducer);
+            const emptyState = createIndexedState();
+            expect(selectOptimistic(() => 1337)(emptyState)).toEqual(1337);
         });
 
-        test('should apply transitions as if committed and run selector', () =>
-            expect(selectOptimistic(selectState)(state)).toEqual({ [item.id]: item }));
+        test('should apply transitions as if committed and run selector', () => {
+            const { selectOptimistic } = optimistron('test', {}, indexedState, reducer);
+            expect(selectOptimistic(selectState)(state)).toEqual({ [item.id]: item });
+        });
 
         test('should warn and return committed state on replay error', () => {
-            optimistron(
-                'test-throw',
+            const { selectOptimistic } = optimistron(
+                'test',
                 {},
                 indexedState,
                 () => {
@@ -49,16 +41,11 @@ describe('selectors', () => {
                 },
             );
 
-            const errorState = {
-                [REDUCER_KEY]: 'test-throw',
-                state: {},
-                transitions: [stage],
-            } as typeof state;
+            const errorState = createIndexedState([stage]);
 
             warn.mockClear();
             expect(selectOptimistic(selectState)(errorState)).toEqual(errorState.state);
             expect(warn).toHaveBeenCalledTimes(1);
-            ReducerMap.delete('test-throw');
         });
     });
 

--- a/test/unit/state.spec.ts
+++ b/test/unit/state.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
-import { REDUCER_KEY } from '~constants';
 import type { StateHandler } from '~state';
-import { bindStateFactory, buildTransitionState, isTransitionState, transitionStateFactory } from '~state';
+import { bindStateFactory, buildTransitionState, transitionStateFactory } from '~state';
 import { create, createIndexedState, createItem } from '~test/utils';
 
 describe('state', () => {
@@ -45,29 +44,17 @@ describe('state', () => {
         });
     });
 
-    describe('isTransitionState', () => {
-        test('should return `true` if `ReducerIdKey` in parameter', () => {
-            expect(isTransitionState({ [REDUCER_KEY]: 'test' })).toBe(true);
-        });
-
-        test('should return `false` otherwise', () => {
-            expect(isTransitionState({})).toBe(false);
-        });
-    });
-
     describe('buildTransitionState', () => {
-        test('should return state clone if already is a transition state', () => {
-            const state = createIndexedState();
-            const result = buildTransitionState(state, [], 'test');
+        test('should build transition state with non-enumerable transitions', () => {
+            const result = buildTransitionState({}, []);
 
-            expect(isTransitionState(result)).toBe(true);
-            expect(state).toMatchObject(result);
+            expect(result.state).toEqual({});
+            expect(result.transitions).toEqual([]);
+            expect(Object.keys(result)).not.toContain('transitions');
         });
 
-        test('should build transition state otherwise', () => {
-            const result = buildTransitionState({}, [], 'test');
-
-            expect(isTransitionState(result)).toBe(true);
+        test('should match createIndexedState structure', () => {
+            const result = buildTransitionState({}, []);
             expect(result).toMatchObject(createIndexedState());
         });
     });

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,5 +1,4 @@
 import { createTransitions } from '~actions';
-import { REDUCER_KEY } from '~constants';
 import type { HandlerReducer } from '~reducer';
 import type { TransitionState } from '~state';
 import { indexedStateFactory } from '~state/indexed';
@@ -47,7 +46,6 @@ export const reducer: HandlerReducer<TestIndexedState, [item: TestItem], [id: st
 };
 
 export const createIndexedState = (transitions: StagedAction[] = []): TransitionState<TestIndexedState> => ({
-    [REDUCER_KEY]: 'test',
     state: {},
     transitions,
 });

--- a/usecases/lib/store/reducer.ts
+++ b/usecases/lib/store/reducer.ts
@@ -26,7 +26,7 @@ const compare = (a: Todo) => (b: Todo) => {
 
 const eq = (a: Todo) => (b: Todo) => a.done === b.done && a.value === b.value;
 
-export const todos = optimistron(
+export const { reducer: todos, selectOptimistic } = optimistron(
     'todos',
     initial,
     indexedStateFactory<Todo>({ itemIdKey: 'id', compare, eq }),

--- a/usecases/lib/store/selectors.ts
+++ b/usecases/lib/store/selectors.ts
@@ -5,8 +5,8 @@ import {
     selectIsConflicting,
     selectIsFailed,
     selectIsOptimistic,
-    selectOptimistic,
 } from '~selectors';
+import { selectOptimistic } from '~usecases/lib/store/reducer';
 import type { State } from '~usecases/lib/store/store';
 
 export const selectTodo = (id: string) =>


### PR DESCRIPTION
1. Removed ReducerMap — optimistron() now returns { reducer,
  selectOptimistic }

  - src/optimistron.ts — Returns { reducer, selectOptimistic }
  instead of bare Reducer. The selectOptimistic is closed over
  the boundReducer — no global lookup. Removed ReducerMap.set()
  call and duplicate registration check.
  - src/selectors.ts — Replaced standalone selectOptimistic with
  createSelectOptimistic factory that takes a BoundReducer and
  namespace. Used internally by optimistron().
  - src/reducer.ts — Deleted ReducerMap.
  - src/constants.ts — Deleted REDUCER_KEY.
  - src/state.ts — Removed REDUCER_KEY from TransitionState,
  buildTransitionState, and transitionStateFactory. Deleted
  isTransitionState. Added writable: true to the transitions
  property descriptor.
  - src/index.ts — Removed selectOptimistic from standalone
  exports.

  2. Extracted commit logic from reducer closure

  - src/optimistron.ts — Extracted commitTransition as a pure
  module-level helper function.

  3. Tightened generic constraints: any[] → unknown[]

  - src/state.ts — StateHandler, BoundStateHandler,
  bindStateFactory
  - src/reducer.ts — HandlerReducer, bindReducer
  - src/optimistron.ts — function signature
  - src/transitions.ts — sanitizeTransitions

  4. FIne tune types